### PR TITLE
fix: Improve June Bug tooltip positioning and dismiss behavior

### DIFF
--- a/src/components/floating-june-bug.tsx
+++ b/src/components/floating-june-bug.tsx
@@ -17,18 +17,24 @@ export function FloatingJuneBug({
   const [isAnimating, setIsAnimating] = useState(false)
   const [shouldWiggle, setShouldWiggle] = useState(false)
 
+  // Check if user has already seen the prompt
   useEffect(() => {
     if (shouldAnimate) {
-      setIsAnimating(true)
-      // Animation lasts 3 seconds before completing
-      const timer = setTimeout(() => {
-        setIsAnimating(false)
-        onAnimationComplete()
-      }, 3000)
-
-      return () => clearTimeout(timer)
+      const hasSeenPrompt = localStorage.getItem('juneBugPromptSeen')
+      if (!hasSeenPrompt) {
+        setIsAnimating(true)
+      }
     }
-  }, [shouldAnimate, onAnimationComplete])
+  }, [shouldAnimate])
+
+  // Dismiss animation when sidebar opens and save to localStorage
+  useEffect(() => {
+    if (isSidebarOpen && isAnimating) {
+      setIsAnimating(false)
+      localStorage.setItem('juneBugPromptSeen', 'true')
+      onAnimationComplete()
+    }
+  }, [isSidebarOpen, isAnimating, onAnimationComplete])
 
   // Happy wiggle when sidebar opens
   useEffect(() => {
@@ -74,7 +80,7 @@ export function FloatingJuneBug({
         )}
       </div>
       {isAnimating && (
-        <div className="absolute -top-12 left-1/2 -translate-x-1/2 whitespace-nowrap">
+        <div className="absolute bottom-0 right-full mr-3 whitespace-nowrap">
           <div className="bg-primary text-primary-foreground px-3 py-1.5 rounded-md text-sm font-medium shadow-lg animate-in fade-in zoom-in-95 duration-300">
             Click me for prompts! 🎯
           </div>

--- a/src/routes/entries.{-$entryId}.tsx
+++ b/src/routes/entries.{-$entryId}.tsx
@@ -181,8 +181,6 @@ function RouteComponent() {
       setSelectedCategory(null)
     }
     toggleRightSidebar()
-    // Clicking the logo stops the animation
-    setShowJuneBugAnimation(false)
   }
 
   // Handle animation completion


### PR DESCRIPTION
## Summary
- Fixed tooltip positioning to prevent cut-off at screen edge (moved from top-center to left of icon)
- Added localStorage persistence so tooltip only shows once per user
- Updated dismiss logic to only trigger when sidebar opens (removed 3-second timeout and click-to-dismiss)

## Test plan
- [ ] Create a new entry as a first-time user and verify tooltip appears to the left of the June Bug icon
- [ ] Verify tooltip is not cut off by the screen edge
- [ ] Click the June Bug icon and verify tooltip remains visible
- [ ] Verify tooltip disappears when the sidebar opens
- [ ] Refresh the page and verify tooltip does not appear again (localStorage persistence)
- [ ] Clear localStorage and verify tooltip appears again on next new entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)